### PR TITLE
feat: 開発用依存関係のコミットスコープをdeps-devに追加

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -3,6 +3,24 @@
   "labels": ["Type: Dependencies"],
   "packageRules": [
     {
+      "description": "開発用依存関係のコミットスコープをdeps-devにします",
+      "semanticCommitScope": "deps-dev",
+      "matchDepTypes": [
+        "build",
+        "build-dependencies",
+        "dev",
+        "dev-dependencies",
+        "dev-packages",
+        "devDependencies",
+        "dev_dependencies",
+        "development",
+        "plugin",
+        "require-dev",
+        "test",
+        "tool"
+      ]
+    },
+    {
       "enabled": false,
       "matchPackageNames": ["@types/node"],
       "matchUpdateTypes": ["major"]


### PR DESCRIPTION
既知のtypesについて追加しています。

- packageRulesにsemanticCommitScope: deps-devを設定
- matchDepTypesに開発系依存タイプを複数追加
