### PR TITLE
feat: アップデートにdelayを追加

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,6 +6,7 @@
     "github>ncaq/renovate-config//preset/deps-dev-dependency-commit-scope",
     "github>ncaq/renovate-config//preset/disable-node-major-update",
     "github>ncaq/renovate-config//preset/lock-file-maintenance",
+    "github>ncaq/renovate-config//preset/minimum-release-age",
     "github>ncaq/renovate-config//preset/prefer-renovate",
     "github>ncaq/renovate-config//preset/schedule-nix-flake-input-weekly"
   ]

--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -6,6 +6,7 @@
     "github>ncaq/renovate-config//preset/deps-dev-dependency-commit-scope",
     "github>ncaq/renovate-config//preset/disable-node-major-update",
     "github>ncaq/renovate-config//preset/lock-file-maintenance",
+    "github>ncaq/renovate-config//preset/minimum-release-age",
     "github>ncaq/renovate-config//preset/prefer-dependabot",
     "github>ncaq/renovate-config//preset/schedule-nix-flake-input-weekly"
   ]

--- a/preset/minimum-release-age.json
+++ b/preset/minimum-release-age.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "minimumReleaseAge": "1 day",
+  "packageRules": [
+    {
+      "description": [
+        "npmとpypi系統はサプライチェーン攻撃がされることが多く、セキュリティ通知はGitHubアラートでわかるので、長めに待機します"
+      ],
+      "matchManagers": [
+        "bun",
+        "npm",
+        "pep621",
+        "pep723",
+        "pip-compile",
+        "pip_requirements",
+        "pip_setup",
+        "pipenv",
+        "pixi",
+        "poetry",
+        "setup-cfg"
+      ],
+      "minimumReleaseAge": "7 days"
+    }
+  ]
+}


### PR DESCRIPTION
サプライチェーン攻撃対策。
ただしセキュリティフィックスを別口に、
全てのマネージャで適用するのは難しいので、
全体では遅らせるのは1日に留めておきます。
npmとpip系統はよくサプライチェーン攻撃の対象になっていますし、
GitHub経由で脆弱性通知がサポートされているので、
7日遅らせています。

close #31
