### PR TITLE
refactor: `lock-file-maintenance` プリセットを公式の `:maintainLockFilesMonthly` に置き換え

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,12 +6,12 @@
   "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
   "extends": [
     "config:best-practices",
+    ":maintainLockFilesMonthly",
     "github>ncaq/renovate-config//preset/prefer-renovate",
     "github>ncaq/renovate-config//preset/base",
     "github>ncaq/renovate-config//preset/claude-marketplace",
     "github>ncaq/renovate-config//preset/deps-dev-dependency-commit-scope",
     "github>ncaq/renovate-config//preset/disable-node-major-update",
-    "github>ncaq/renovate-config//preset/lock-file-maintenance",
     "github>ncaq/renovate-config//preset/minimum-release-age",
     "github>ncaq/renovate-config//preset/schedule-nix-flake-input-weekly"
   ]

--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -6,12 +6,12 @@
   "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
   "extends": [
     "config:best-practices",
+    ":maintainLockFilesMonthly",
     "github>ncaq/renovate-config//preset/prefer-dependabot",
     "github>ncaq/renovate-config//preset/base",
     "github>ncaq/renovate-config//preset/claude-marketplace",
     "github>ncaq/renovate-config//preset/deps-dev-dependency-commit-scope",
     "github>ncaq/renovate-config//preset/disable-node-major-update",
-    "github>ncaq/renovate-config//preset/lock-file-maintenance",
     "github>ncaq/renovate-config//preset/minimum-release-age",
     "github>ncaq/renovate-config//preset/schedule-nix-flake-input-weekly"
   ]

--- a/preset/lock-file-maintenance.json
+++ b/preset/lock-file-maintenance.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "lockFileMaintenance": {
-    "enabled": true,
-    "extends": ["schedule:monthly"]
-  }
-}


### PR DESCRIPTION
カスタムの `preset/lock-file-maintenance.json` は Renovate 公式プリセットの
`:maintainLockFilesMonthly` と完全に同一の内容でした。
独自に保持する意味がないため、
`default.json` と `org-inherited-config.json` の参照を公式プリセットに置き換え、
カスタムプリセットファイルを削除します。

`config:best-practices` には `:maintainLockFilesWeekly` が含まれているため、
後に `:maintainLockFilesMonthly` を記述することで週次を月次に上書きしています。
