### PR TITLE
fix(claude-marketplace): refをすべてGitHubタグdatasourceで扱うように統一

### DIFF
--- a/preset/claude-marketplace.json
+++ b/preset/claude-marketplace.json
@@ -8,20 +8,9 @@
       ],
       "managerFilePatterns": ["/(^|/)settings\\.json$/"],
       "matchStrings": [
-        "\"repo\":\\s*\"(?<depName>[^\"]+)\"[^{}]*?\"ref\":\\s*\"(?<currentValue>[^@\"][^\"]*)\""
+        "\"repo\":\\s*\"(?<depName>[^\"]+)\"[^{}]*?\"ref\":\\s*\"(?<currentValue>[^\"]+)\""
       ],
       "datasourceTemplate": "github-tags"
-    },
-    {
-      "customType": "regex",
-      "description": [
-        "Claude CodeプラグインマーケットプレイスのnpmパッケージrefをJSON形式のファイルで自動更新します"
-      ],
-      "managerFilePatterns": ["/(^|/)settings\\.json$/"],
-      "matchStrings": [
-        "\"ref\":\\s*\"(?<depName>@[^@\"]+)@(?<currentValue>[^\"]+)\""
-      ],
-      "datasourceTemplate": "npm"
     },
     {
       "customType": "regex",
@@ -30,20 +19,9 @@
       ],
       "managerFilePatterns": ["/\\.nix$/"],
       "matchStrings": [
-        "source\\s*=\\s*\"github\";[^}]*?repo\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?ref\\s*=\\s*\"(?<currentValue>[^@\"][^\"]*)\";"
+        "source\\s*=\\s*\"github\";[^}]*?repo\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?ref\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
       ],
       "datasourceTemplate": "github-tags"
-    },
-    {
-      "customType": "regex",
-      "description": [
-        "Claude CodeプラグインマーケットプレイスのnpmパッケージrefをNix形式のファイルで自動更新します"
-      ],
-      "managerFilePatterns": ["/\\.nix$/"],
-      "matchStrings": [
-        "ref\\s*=\\s*\"(?<depName>@[^@\"]+)@(?<currentValue>[^\"]+)\";"
-      ],
-      "datasourceTemplate": "npm"
     }
   ]
 }


### PR DESCRIPTION
`@scope/name@version`形式のrefをnpm datasourceとして扱う設定を削除し、
すべて`github-tags` datasourceに一本化します。

monorepoでは`@upstash/context7-mcp@2.2.3`のようなタグが
GitHubのリリースタグとしても普通に切られているため、
`@`の有無でnpmかGitHubかを判別する根拠は薄いと判断しました。
Claudeマーケットプレイスは`source = "github"`でrepoとrefを参照するので、
実際の取得元と一致する`github-tags`に揃える方が概念的にも整合します。

monorepoで複数パッケージのタグが混在する場合でも、
最新のタグを採用する運用で問題ないという方針を採用しています。
