### PR TITLE
fix: commit typeを確実にbuildにする

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,7 +3,6 @@
   "description": [
     "extendsの順序はpackageRulesの優先順位に影響します。後に記述されたルールが優先されるため、広範囲にenabledを設定するprefer-renovateを先に置き、個別の制限を後に置いてください。順序に依存しないプリセットは辞書順にソートしています。"
   ],
-  "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
   "extends": [
     "config:best-practices",
     ":maintainLockFilesMonthly",
@@ -13,6 +12,7 @@
     "github>ncaq/renovate-config//preset/deps-dev-dependency-commit-scope",
     "github>ncaq/renovate-config//preset/disable-node-major-update",
     "github>ncaq/renovate-config//preset/minimum-release-age",
-    "github>ncaq/renovate-config//preset/schedule-nix-flake-input-weekly"
+    "github>ncaq/renovate-config//preset/schedule-nix-flake-input-weekly",
+    "github>ncaq/renovate-config//preset/semantic-commit-type-build"
   ]
 }

--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -3,7 +3,6 @@
   "description": [
     "extendsの順序はpackageRulesの優先順位に影響します。後に記述されたルールが優先されるため、広範囲にenabledを設定するprefer-dependabotを先に置き、個別の制限を後に置いてください。順序に依存しないプリセットは辞書順にソートしています。"
   ],
-  "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
   "extends": [
     "config:best-practices",
     ":maintainLockFilesMonthly",
@@ -13,6 +12,7 @@
     "github>ncaq/renovate-config//preset/deps-dev-dependency-commit-scope",
     "github>ncaq/renovate-config//preset/disable-node-major-update",
     "github>ncaq/renovate-config//preset/minimum-release-age",
-    "github>ncaq/renovate-config//preset/schedule-nix-flake-input-weekly"
+    "github>ncaq/renovate-config//preset/schedule-nix-flake-input-weekly",
+    "github>ncaq/renovate-config//preset/semantic-commit-type-build"
   ]
 }

--- a/preset/base.json
+++ b/preset/base.json
@@ -3,7 +3,6 @@
   "timezone": "Asia/Tokyo",
   "branchConcurrentLimit": 20,
   "labels": ["Type: Dependencies"],
-  "semanticCommitType": "build",
   "vulnerabilityAlerts": {
     "enabled": true,
     "addLabels": ["Type: Security"]

--- a/preset/semantic-commit-type-build.json
+++ b/preset/semantic-commit-type-build.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "semanticCommitType": "build",
+  "packageRules": [
+    {
+      "description": [
+        "`config:best-practices`経由で読み込まれる`:semanticPrefixFixDepsChoreOthers`などの`packageRules`がroot設定の`semanticCommitType`を上書きしてしまうため、後勝ちする`packageRules`で再度buildに統一します"
+      ],
+      "matchPackageNames": ["*"],
+      "semanticCommitType": "build"
+    }
+  ]
+}


### PR DESCRIPTION
`ignorePresets`を使う方法では、
一部のPresetsを無効化したいリポジトリ特有の設定を入れると、
マージではなく上書きされてしまうため、
`packageRules`で再度上書きする方法に切り替えます。
