### PR TITLE
fix(claude-marketplace): コミットスコープを`deps-dev`にする

### DIFF
--- a/preset/claude-marketplace.json
+++ b/preset/claude-marketplace.json
@@ -10,7 +10,8 @@
       "matchStrings": [
         "\"repo\":\\s*\"(?<depName>[^\"]+)\"[^{}]*?\"ref\":\\s*\"(?<currentValue>[^\"]+)\""
       ],
-      "datasourceTemplate": "github-tags"
+      "datasourceTemplate": "github-tags",
+      "depTypeTemplate": "claude-code-marketplace"
     },
     {
       "customType": "regex",
@@ -21,7 +22,8 @@
       "matchStrings": [
         "source\\s*=\\s*\"github\";[^}]*?repo\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?ref\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
       ],
-      "datasourceTemplate": "github-tags"
+      "datasourceTemplate": "github-tags",
+      "depTypeTemplate": "claude-code-marketplace"
     }
   ]
 }

--- a/preset/deps-dev-dependency-commit-scope.json
+++ b/preset/deps-dev-dependency-commit-scope.json
@@ -7,6 +7,7 @@
       "matchDepTypes": [
         "build",
         "build-dependencies",
+        "claude-code-marketplace",
         "dev",
         "dev-dependencies",
         "dev-packages",


### PR DESCRIPTION
Claude Codeのマーケットプレイス更新は開発用ツールに分類されるべきですが、
customManagerに`depType`が設定されていないため、
`deps-dev-dependency-commit-scope`プリセットの`matchDepTypes`にマッチせず、
コミットスコープがデフォルトの`deps`になっていました。

customManagerに`depTypeTemplate`で独自のdepType `claude-code-marketplace`を付与し、
それを`deps-dev-dependency-commit-scope`の`matchDepTypes`に追加することで、
`build(deps-dev): ...`のスコープでコミットが生成されるようにします。

GradleやsbtなどでRenovate標準で使われる汎用的な`plugin`を流用するのではなく、
Claude Codeのマーケットプレイス由来の更新であることが識別できる名前にしています。
また実際に更新しているのはマーケットプレイス自体のGitHubタグであり、
個々のプラグインのバージョンを更新しているわけではないため、
`claude-code-plugin`ではなく`claude-code-marketplace`を採用しました。
