### PR TITLE
refactor: add $schema to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "extraKnownMarketplaces": {
     "konoka": {
       "source": {


### PR DESCRIPTION
## 概要

`.claude/settings.json` に `$schema` フィールドを追加し、IDEの補完・バリデーションを有効にします。

使用するスキーマ: https://json.schemastore.org/claude-code-settings.json