### PR TITLE
feat: Effectモノレポのパッケージをグループ化するプリセットを追加

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,6 +11,7 @@
     "github>ncaq/renovate-config//preset/claude-marketplace",
     "github>ncaq/renovate-config//preset/deps-dev-dependency-commit-scope",
     "github>ncaq/renovate-config//preset/disable-node-major-update",
+    "github>ncaq/renovate-config//preset/group-effect-monorepo",
     "github>ncaq/renovate-config//preset/minimum-release-age",
     "github>ncaq/renovate-config//preset/schedule-nix-flake-input-monthly",
     "github>ncaq/renovate-config//preset/semantic-commit-type-build"

--- a/preset/group-effect-monorepo.json
+++ b/preset/group-effect-monorepo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": [
+        "Effectはeffect本体と@effect/*スコープのパッケージがバージョン連動するモノレポです。しかしRenovate本体のmonorepo:effect定義はEffect-TS/effect-smolだけを指しているため、本家Effect-TS/effect由来のパッケージはグループ化されません。sourceUrlでマッチさせて1つのグループとして更新します。"
+      ],
+      "groupName": "effect monorepo",
+      "matchSourceUrls": ["https://github.com/Effect-TS/effect"]
+    }
+  ]
+}


### PR DESCRIPTION
npmパッケージの`effect`本体と`@effect/*`スコープのパッケージ群は、
モノレポhttps://github.com/Effect-TS/effectでバージョンを連動させて開発されていますが、
Renovateはこれらをバラバラのプルリクエストとして更新していました。

Renovate本体には`monorepo:effect`定義が存在するものの、
そのmatchSourceUrlsは実験的な次世代リポジトリのEffect-TS/effect-smolだけを指しており、
本家Effect-TS/effect由来のパッケージにはマッチしないことが原因です。

`preset/group-effect-monorepo`を追加し、
sourceUrlが本家リポジトリを指すパッケージを`effect monorepo`グループとしてまとめて更新します。
パッケージ名のglobではなくsourceUrlでマッチさせることで、
別リポジトリ由来で独立したバージョンを持つ`@effect/language-service`などを誤って巻き込みません。

https://claude.ai/code/session_01Xn7ZbERnKd6ERegDAgt7Zi