### PR TITLE
feat: npmとpypiの`minimumReleaseAge`を3 daysに緩和

### DIFF
--- a/preset/minimum-release-age.json
+++ b/preset/minimum-release-age.json
@@ -19,7 +19,7 @@
         "poetry",
         "setup-cfg"
       ],
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "3 days"
     }
   ]
 }


### PR DESCRIPTION
流石に7 daysは長過ぎて開発に支障が出ることが分かってきました。
3日経ってもサプライチェーン攻撃が発覚しないなら、
どうせ多少の時間をおいても発覚可能性はそう増えないと思うので、
3日程度に緩和します。
